### PR TITLE
Fix Ubuntu deprecated in Dockerfile, add runtime options to Stanford CoreNLP XML Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM ubuntu:14.10
-MAINTAINER Michael De Lorenzo "michael@delorenzodesign.com"
+FROM ubuntu
 
 RUN echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections
 RUN echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu
+MAINTAINER Michael De Lorenzo "michael@delorenzodesign.com"
 
 RUN echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections
 RUN echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections

--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,9 @@
     <property name="lib.dir"     value="lib"/>
 
     <property name="main-class"  value="StanfordCoreNLPXMLServer"/>
-    <property name="port"  value=""/>
+    <property name="port"  value="8080"/>
+    <property name="annotators"  value="tokenize, ssplit, pos, lemma, ner, parse, dcoref, sentiment"/>
+    <property name="maxmemory"  value="1024m"/>
 
     <path id="classpath">
         <fileset dir="${lib.dir}" includes="**/*.jar"/>
@@ -56,14 +58,16 @@
     </target>
 
     <target name="run" depends="jar">
-        <java jar="${jar.dir}/${ant.project.name}.jar" fork="true" maxmemory="1024m">
+        <java jar="${jar.dir}/${ant.project.name}.jar" fork="true" maxmemory="${maxmemory}">
             <arg value="${port}" />
+            <arg value="${annotators}" />
         </java>
     </target>
 
     <target name="test">
-        <java jar="${jar.dir}/${ant.project.name}.jar" fork="true" timeout="30000" maxmemory="1024m">
+        <java jar="${jar.dir}/${ant.project.name}.jar" fork="true" timeout="30000" maxmemory="${maxmemory}">
             <arg value="${port}" />
+            <arg value="${annotators}" />
         </java>
     </target>
 </project>

--- a/src/StanfordCoreNLPXMLServer.java
+++ b/src/StanfordCoreNLPXMLServer.java
@@ -41,7 +41,10 @@ import org.simpleframework.transport.connect.SocketConnection;
 public class StanfordCoreNLPXMLServer implements Container {
     private static StanfordCoreNLP pipeline;
     private static int port = 8080;
-    private static final Logger log = Logger.getLogger( StanfordCoreNLPXMLServer.class.getName() );
+    private static String annotators =
+      "tokenize, ssplit, pos, lemma, ner, parse, dcoref, sentiment";
+    private static final Logger log =
+      Logger.getLogger( StanfordCoreNLPXMLServer.class.getName() );
     private static int total_requests = 0;
 
     // an interface to the Stanford Core NLP
@@ -58,14 +61,14 @@ public class StanfordCoreNLPXMLServer implements Container {
             int request_number = ++total_requests;
             log.info("Request " + request_number + " from " + request.getClientAddress().getHostName());
             long time = System.currentTimeMillis();
-   
+
             response.setValue("Content-Type", "text/xml");
             response.setValue("Server", "Stanford CoreNLP XML Server/1.0 (Simple 5.1.6)");
             response.setDate("Date", time);
             response.setDate("Last-Modified", time);
-   
+
             // pass "text" POST query to Stanford Core NLP parser
-            String text = request.getQuery().get("text");  
+            String text = request.getQuery().get("text");
             PrintStream body = response.getPrintStream();
             body.println(parse(text));
             body.close();
@@ -75,12 +78,14 @@ public class StanfordCoreNLPXMLServer implements Container {
         } catch(Exception e) {
             log.log(Level.SEVERE, "Exception", e);
         }
-    } 
+    }
 
     public static void main(String args[]) throws Exception {
-        // use port if given
+        // use port and annotators if given
         try {
             port = Integer.parseInt(args[0]);
+            annotators = !args[1].isEmpty() ?
+              args[1].trim() : annotators;
         } catch(Exception e) {
             // silently keep port at 8080
         }
@@ -88,7 +93,7 @@ public class StanfordCoreNLPXMLServer implements Container {
         // creates a StanfordCoreNLP object, with POS tagging, lemmatization, NER,
         // parsing, coreference resolution, and sentiment
         Properties defaultProperties = new Properties();
-        defaultProperties.put("annotators", "tokenize, ssplit, pos, lemma, ner, parse, dcoref, sentiment");
+        defaultProperties.put("annotators", annotators);
 
         // initialize the Stanford Core NLP
         pipeline = new StanfordCoreNLP(defaultProperties);


### PR DESCRIPTION
Fix Ubuntu deprecated in Dockerfile, add runtime options to Stanford CoreNLP XML Server

1. Update Dockerfile setting `ubuntu:14.10` to `ubuntu`. 
`docker build` would not complete due to deprecated Ubuntu 14.10 apt sources.

2. Add runtime options to Stanford CoreNLP XML Server including: 

  - annotators: Specify annotators as desired.
  - maxmemory: Tailor java maxmemory. 

Update `build.xml`, Add properties `annotators` and `maxmemory`, Update `run` and `test` targets using these properties.
Update `StanfordCoreNLPXMLServer.java`, use the `annotators` argument if supplied, otherwise default.

Usage examples:

    #port 8080, all annotators, maxmemory=1024m
    ant run

    #port 8081, "tokenize, ssplit, pos" annotators, maxmemory=2048m
    ant run -Dport=8081 -Dannotators="tokenize, ssplit, pos" -Dmaxmemory=2048m