### PR TITLE
update StanfordCoreNLP to v3.8, monkey patch broken oracle-java8-inst…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,17 @@ RUN echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-s
 RUN echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:webupd8team/java && \
+    apt-get install -y --no-install-recommends software-properties-common
+
+RUN add-apt-repository ppa:webupd8team/java && \
     apt-get update && \
-    apt-get install -y --no-install-recommends oracle-java8-installer
+    apt-get install -y --no-install-recommends oracle-java8-installer || true && \
+    cd /var/lib/dpkg/info && \
+    sed -i 's|JAVA_VERSION=8u151|JAVA_VERSION=8u162|' oracle-java8-installer.* && \
+    sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/|' oracle-java8-installer.*  && \
+    sed -i 's|SHA256SUM_TGZ="c78200ce409367b296ec39be4427f020e2c585470c4eed01021feada576f027f"|SHA256SUM_TGZ="68ec82d47fd9c2b8eb84225b6db398a72008285fafc98631b1ff8d2229680257"|' oracle-java8-installer.*  && \
+    sed -i 's|J_DIR=jdk1.8.0_151|J_DIR=jdk1.8.0_162|' oracle-java8-installer.* && \
+    apt-get install -f -y
 
 RUN apt-get install -y ant
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ This software offers the functionality of the [Stanford CoreNLP](http://nlp.stan
 
 The server will be listening at <http://localhost:8080>. The text you want to analyze needs to be POSTed as field `text`:
 
-     curl --data 'text=Hello world!' http://localhost:8080
+     curl -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
+       --data 'text=Hello world!' http://localhost:8080
+
+The `Content-Type` / `charset` header is set to `utf-8` to ensure that all unicode characters are correctly parsed.   
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -87,11 +90,11 @@ Note you can olso try this [online](http://nlp.stanford.edu:8080/corenlp/process
 ## Installation
 
 1. Clone the repository:
-    
+
         git clone https://github.com/michaeldelorenzo/StanfordCoreNLPXMLServer.git
 
 2. Download and install the third party libraries:
-    
+
         cd StanfordCoreNLPXMLServer
         ant libs
 

--- a/build.xml
+++ b/build.xml
@@ -31,15 +31,15 @@
     </target>
 
     <target name="stanford">
-        <get src="http://nlp.stanford.edu/software/stanford-corenlp-full-2014-06-16.zip" dest="stanford-corenlp-full-2014-06-16.zip" />
-        <unzip src="stanford-corenlp-full-2014-06-16.zip" dest="." />
+        <get src="http://nlp.stanford.edu/software/stanford-corenlp-full-2017-06-09.zip" dest="stanford-corenlp-full-2017-06-09.zip" />
+        <unzip src="stanford-corenlp-full-2017-06-09.zip" dest="." />
         <move todir="${lib.dir}">
-            <fileset dir="stanford-corenlp-full-2014-06-16">
+            <fileset dir="stanford-corenlp-full-2017-06-09">
                 <include name="**/*.jar" />
             </fileset>
         </move>
-        <delete dir="stanford-corenlp-full-2014-06-16" />
-        <delete file="stanford-corenlp-full-2014-06-16.zip" />
+        <delete dir="stanford-corenlp-full-2017-06-09" />
+        <delete file="stanford-corenlp-full-2017-06-09.zip" />
     </target>
 
     <target name="compile">

--- a/src/StanfordCoreNLPXMLServer.java
+++ b/src/StanfordCoreNLPXMLServer.java
@@ -62,7 +62,7 @@ public class StanfordCoreNLPXMLServer implements Container {
             log.info("Request " + request_number + " from " + request.getClientAddress().getHostName());
             long time = System.currentTimeMillis();
 
-            response.setValue("Content-Type", "text/xml");
+            response.setValue("Content-Type", "text/xml; charset=UTF-8");
             response.setValue("Server", "Stanford CoreNLP XML Server/1.0 (Simple 5.1.6)");
             response.setDate("Date", time);
             response.setDate("Last-Modified", time);
@@ -94,7 +94,7 @@ public class StanfordCoreNLPXMLServer implements Container {
         // parsing, coreference resolution, and sentiment
         Properties defaultProperties = new Properties();
         defaultProperties.put("annotators", annotators);
-
+        
         // initialize the Stanford Core NLP
         pipeline = new StanfordCoreNLP(defaultProperties);
         // start the server


### PR DESCRIPTION
…aller, fix utf-8 encoding issue

- update StanfordCoreNLP to v3.8

- monkey patch broken oracle-java8-installer
As of Jan-2018, the oracle-java8-installer has temporarily broken with a new java 1.8 version being available. Applied monkey patch as described here: https://stackoverflow.com/a/48343372/4852737

- fix utf-8 encoding issue
Updated README to specify that the Content-Type / charset header must be set to utf-8 in order to correctly encode multibyte characters.
Updated StanfordCoreNLPXMLServer.java to set the response charset header to utf-8.